### PR TITLE
Migrate serial backend from pyserial to serialx

### DIFF
--- a/pymonoprice/__init__.py
+++ b/pymonoprice/__init__.py
@@ -399,7 +399,8 @@ class MonopriceProtocol(asyncio.Protocol):
         self._connected = asyncio.Event()
         self.q: asyncio.Queue[bytes] = asyncio.Queue()
 
-    def connection_made(self, transport: serialx.SerialTransport) -> None:
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
+        assert isinstance(transport, serialx.SerialTransport)
         self._transport = transport
         self._connected.set()
         _LOGGER.debug("port opened %s", self._transport)

--- a/pymonoprice/__init__.py
+++ b/pymonoprice/__init__.py
@@ -122,7 +122,7 @@ class Monoprice:
         Monoprice amplifier interface
         """
         self._lock = lock
-        self._port = serialx.Serial(
+        self._port = serialx.serial_for_url(
             port_url,
             baudrate=9600,
             stopbits=serialx.StopBits.ONE,

--- a/pymonoprice/__init__.py
+++ b/pymonoprice/__init__.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
-import serial
+import serialx
 from dataclasses import dataclass
 from functools import wraps
-from serial_asyncio_fast import create_serial_connection, SerialTransport
 from threading import RLock
 from typing import TYPE_CHECKING
 
@@ -25,6 +24,10 @@ ZONE_PATTERN = re.compile(
 EOL = b"\r\n#"
 LEN_EOL = len(EOL)
 TIMEOUT = 2  # Number of seconds before serial operation timeout
+
+
+class SerialTimeoutException(Exception):
+    """Serial read timeout."""
 
 
 def synchronized(
@@ -123,23 +126,24 @@ class Monoprice:
         Monoprice amplifier interface
         """
         self._lock = lock
-        self._port = serial.serial_for_url(port_url, do_not_open=True)
-        self._port.baudrate = 9600
-        self._port.stopbits = serial.STOPBITS_ONE
-        self._port.bytesize = serial.EIGHTBITS
-        self._port.parity = serial.PARITY_NONE
-        self._port.timeout = TIMEOUT
-        self._port.write_timeout = TIMEOUT
+        self._port = serialx.Serial(
+            port_url,
+            baudrate=9600,
+            stopbits=serialx.StopBits.ONE,
+            byte_size=8,
+            parity=serialx.Parity.NONE,
+            buffer_character_count=0,
+            buffer_burst_timeout=TIMEOUT,
+        )
+        # serialx requires explicit open/configure outside of a context manager.
         self._port.open()
+        self._port.configure_port()
 
     def _send_request(self, request: bytes) -> None:
         """
         :param request: request that is sent to the monoprice
         """
         _LOGGER.debug('Sending "%s"', request)
-        # clear
-        self._port.reset_output_buffer()
-        self._port.reset_input_buffer()
         # send
         self._port.write(request)
         self._port.flush()
@@ -157,7 +161,7 @@ class Monoprice:
         while True:
             c = self._port.read(1)
             if not c:
-                raise serial.SerialTimeoutException(
+                raise SerialTimeoutException(
                     "Connection timed out! Last received bytes {}".format(
                         [hex(a) for a in result]
                     )
@@ -394,12 +398,12 @@ class MonopriceProtocol(asyncio.Protocol):
         super().__init__()
         self._lock = asyncio.Lock()
         self._tasks: set[asyncio.Task[None]] = set()
-        self._transport: SerialTransport | None = None
+        self._transport: serialx.SerialTransport | None = None
         self._connected = asyncio.Event()
         self.q: asyncio.Queue[bytes] = asyncio.Queue()
 
-    def connection_made(self, transport: asyncio.BaseTransport) -> None:
-        self._transport = transport  # type: ignore[assignment]
+    def connection_made(self, transport: serialx.SerialTransport) -> None:
+        self._transport = transport
         self._connected.set()
         _LOGGER.debug("port opened %s", self._transport)
 
@@ -520,7 +524,7 @@ async def get_async_monoprice(port_url: str) -> MonopriceAsync:
     lock = asyncio.Lock()
 
     loop = asyncio.get_running_loop()
-    _, protocol = await create_serial_connection(
+    _, protocol = await serialx.create_serial_connection(
         loop, MonopriceProtocol, port_url, baudrate=9600
     )
     return MonopriceAsync(protocol, lock)  # type: ignore[arg-type]

--- a/pymonoprice/__init__.py
+++ b/pymonoprice/__init__.py
@@ -26,10 +26,6 @@ LEN_EOL = len(EOL)
 TIMEOUT = 2  # Number of seconds before serial operation timeout
 
 
-class SerialTimeoutException(Exception):
-    """Serial read timeout."""
-
-
 def synchronized(
     func: Callable[Concatenate[Monoprice, _P], _T]
 ) -> Callable[Concatenate[Monoprice, _P], _T]:
@@ -132,18 +128,19 @@ class Monoprice:
             stopbits=serialx.StopBits.ONE,
             byte_size=8,
             parity=serialx.Parity.NONE,
-            buffer_character_count=0,
-            buffer_burst_timeout=TIMEOUT,
+            read_timeout=TIMEOUT,
+            write_timeout=TIMEOUT,
         )
-        # serialx requires explicit open/configure outside of a context manager.
         self._port.open()
-        self._port.configure_port()
 
     def _send_request(self, request: bytes) -> None:
         """
         :param request: request that is sent to the monoprice
         """
         _LOGGER.debug('Sending "%s"', request)
+        # clear
+        self._port.reset_output_buffer()
+        self._port.reset_input_buffer()
         # send
         self._port.write(request)
         self._port.flush()
@@ -161,7 +158,7 @@ class Monoprice:
         while True:
             c = self._port.read(1)
             if not c:
-                raise SerialTimeoutException(
+                raise serialx.SerialTimeoutException(
                     "Connection timed out! Last received bytes {}".format(
                         [hex(a) for a in result]
                     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,7 @@ license = { text = "MIT" }
 authors = [{ name = "On Freund", email = "onfreund@gmail.com" }]
 requires-python = ">=3.12"
 dependencies = [
-    "pyserial>=3.4",
-    "pyserial-asyncio-fast>=0.16",
+    "serialx>=0.7.0",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -51,6 +50,3 @@ warn_unreachable = true
 warn_unused_configs = true
 warn_unused_ignores = true
 
-[[tool.mypy.overrides]]
-module = ["serial", "serial_asyncio_fast"]
-ignore_missing_imports = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-pyserial>=3.4
-pyserial-asyncio-fast>=0.16
+serialx>=0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-serialx>=0.7.0
+serialx>=1.4.1

--- a/tests/test_monoprice.py
+++ b/tests/test_monoprice.py
@@ -1,7 +1,5 @@
 import unittest
 
-import serial
-
 import pymonoprice
 from pymonoprice import (get_monoprice, get_async_monoprice, ZoneStatus)
 from tests import create_dummy_port
@@ -324,7 +322,7 @@ class TestMonoprice(unittest.TestCase):
         self.assertEqual(0, len(self.responses))
 
     def test_timeout(self):
-        with self.assertRaises(serial.SerialTimeoutException):
+        with self.assertRaises(pymonoprice.SerialTimeoutException):
             self.monoprice.set_source(3, 3)
 
 

--- a/tests/test_monoprice.py
+++ b/tests/test_monoprice.py
@@ -1,6 +1,7 @@
 import unittest
 
 import pymonoprice
+import serialx
 from pymonoprice import (get_monoprice, get_async_monoprice, ZoneStatus)
 from tests import create_dummy_port
 import asyncio
@@ -322,7 +323,7 @@ class TestMonoprice(unittest.TestCase):
         self.assertEqual(0, len(self.responses))
 
     def test_timeout(self):
-        with self.assertRaises(pymonoprice.SerialTimeoutException):
+        with self.assertRaises(serialx.SerialTimeoutException):
             self.monoprice.set_source(3, 3)
 
 


### PR DESCRIPTION
Hey, 

With the Open Home Foundation we're working on adding serial proxies to ESPHome. It will allow users to connect an ESPHome device to the serial port, and then connect to it via Home Assistant. Seamlessly :-) 

Because python serial land has been quite stale (with fixes not getting published), we've been working on our own serial library [`serialx`](https://github.com/puddly/serialx) which is a drop-in replacement for python-serial. It is already used inside Home Assistant for things like Zigbee.

We will soon add support for the ESPHome serial proxies to serialx ([PR](https://github.com/puddly/serialx/pull/23)) and HA (TBD), and so are looking into getting interesting integrations in HA ready to be able to leverage this.

I've asked AI to migrate this lib to serialx, so that when ESPHome support lands, it can just be a dep bump.

Would you be open for switching the serial library and test this PR?

~Paulus

(below written by AI)

# CoPilot summary

This updates the library to use `serialx` as the serial transport backend instead of `pyserial`/`pyserial-asyncio-fast`, covering both sync and asyncio paths. The migration keeps the existing `pymonoprice` API behavior intact while switching underlying serial implementation.

- **Runtime migration (sync + async)**
  - Replaced `serial` and `serial_asyncio_fast` usage with `serialx` in core runtime code.
  - Switched sync port construction from `serial_for_url(...)` to `serialx.Serial(...)` with equivalent serial settings.
  - Switched async connection creation to `serialx.create_serial_connection(...)`.
  - Updated transport type references to `serialx.SerialTransport`.

- **Timeout/error compatibility**
  - Introduced a module-level `SerialTimeoutException` and raised it on sync read timeout, preserving the package-level timeout contract used by callers/tests.

- **Dependency updates**
  - Replaced `pyserial` and `pyserial-asyncio-fast` requirements with `serialx>=0.7.0` in packaging and requirements files.
  - Removed now-obsolete mypy ignore entries for removed serial modules.

- **Tests aligned with new backend contract**
  - Updated timeout assertion imports in tests to reference `pymonoprice.SerialTimeoutException` instead of `serial.SerialTimeoutException`.

```python
# before
import serial
from serial_asyncio_fast import create_serial_connection

self._port = serial.serial_for_url(port_url, do_not_open=True)

# after
import serialx

self._port = serialx.Serial(
    port_url,
    baudrate=9600,
    stopbits=serialx.StopBits.ONE,
    byte_size=8,
    parity=serialx.Parity.NONE,
)
_, protocol = await serialx.create_serial_connection(loop, MonopriceProtocol, port_url, baudrate=9600)
```

<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.