### PR TITLE
Exclude docs/ from wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,11 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/OnFreund/pymonoprice"
 
+[tool.setuptools]
+include-package-data = false
+
 [tool.setuptools.packages.find]
-exclude = ["tests*"]
+include = ["pymonoprice*"]
 
 [tool.setuptools.package-data]
 pymonoprice = ["py.typed"]


### PR DESCRIPTION
## What changed

`setuptools-scm`'s file finder hooks into setuptools and includes all git-tracked files in the built wheel. This caused `docs/rs232-protocol.md` to appear as a top-level `docs/` directory in the wheel, which Home Assistant flags as unexpected.

## Fix

Two changes to `pyproject.toml`:

- `include-package-data = false` — disables the setuptools-scm file finder from auto-including non-package files
- `packages.find.include = ["pymonoprice*"]` — replaces the old `exclude = ["tests*"]` with an explicit allowlist (safer and clearer)

## Verification

Built the wheel from a clean state and confirmed the contents are now only `pymonoprice/__init__.py`, `pymonoprice/py.typed`, and dist-info metadata. `docs/` is gone.